### PR TITLE
Export cache expiry functions

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -52,7 +52,12 @@ export type {
   StacItemsDocument,
 } from './stac/index.js';
 
-export { useCache, clearCache } from './shared/cache.js';
+export {
+  useCache,
+  clearCache,
+  setCacheExpiryDuration,
+  getCacheExpiryDuration,
+} from './shared/cache.js';
 export {
   sharedFetch,
   setFetchOptions,


### PR DESCRIPTION
PR adds the following cache functions to the exports:
- `setCacheExpiryDuration`
- `getCacheExpiryDuration`