### PR TITLE
Prevent tree-shaking of setFetchOptionsUpdateCallback

### DIFF
--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -4,7 +4,10 @@ import {
   OperationName,
   OperationUrl,
 } from '../shared/models.js';
-import { setFetchOptionsUpdateCallback } from '../shared/http-utils.js';
+import {
+  getFetchOptions,
+  setFetchOptionsUpdateCallback,
+} from '../shared/http-utils.js';
 import { WmtsEndpointInfo, WmtsLayer, WmtsMatrixSet } from '../wmts/model.js';
 import {
   WfsFeatureTypeFull,
@@ -37,6 +40,12 @@ function getWorkerInstance() {
   }
   if (!workerInstance) {
     workerInstance = new OgcClientWorker();
+    setFetchOptionsUpdateCallback((options) => {
+      sendTaskRequest('updateFetchOptions', workerInstance, { options });
+    });
+    sendTaskRequest('updateFetchOptions', workerInstance, {
+      options: getFetchOptions(),
+    });
   }
   return workerInstance;
 }
@@ -102,9 +111,3 @@ export function parseWmtsCapabilities(capabilitiesUrl: string): Promise<{
     url: capabilitiesUrl,
   });
 }
-
-setFetchOptionsUpdateCallback((options) => {
-  const worker = getWorkerInstance();
-  if (!worker) return;
-  sendTaskRequest('updateFetchOptions', getWorkerInstance(), { options });
-});

--- a/vite.worker-config.js
+++ b/vite.worker-config.js
@@ -1,5 +1,8 @@
+import { resolve, relative } from 'node:path';
 import { defineConfig } from 'vite';
 import dts from 'vite-plugin-dts';
+
+const srcRoot = resolve('src');
 
 export default defineConfig({
   plugins: [
@@ -17,9 +20,14 @@ export default defineConfig({
     },
     emptyOutDir: false,
     rollupOptions: {
-      external: [/^ol/, 'proj4'],
+      // Inline only the worker code, not the dependencies
+      external: (source, importer) => {
+        if (!importer) return false;
+        if (source.includes('?worker')) return false;
+        return true;
+      },
       output: {
-        globals: (name) => name,
+        paths: (id) => relative(srcRoot, id),
         inlineDynamicImports: true,
       },
     },


### PR DESCRIPTION
The [`initSetFetchOptionsUpdateCallback`](https://github.com/camptocamp/ogc-client/blob/afd9c266cb124c622439677cf438904b7ef1e03f/src/worker/index.ts#L106) call is being removed during vite/rollup tree-shaking (`build:worker` script) because it executes at module scope with no visible side effect tying it to an export.

Moreover, imports from the `shared` modules were being bundled directory by the `build:worker` script rather than treated as external dependencies and resolved by the `build:browser` and `build:node` scripts. This resulted in duplicated generated code and caused issue with callback registration, as the callback was being assigned to the copy within the `worker/index.js` file.

This should fixes #99 and #134

P.S.: The configuration changes do not affect worker inlining, as those settings are controlled independently through `worker.rollupOptions`. You could test those changes by observing the output in `dist/worker/index.js` with and without worker inlining.