### PR TITLE
fix(wfs): use SERVICE=WFS in WfsEndpoint.getCapabilitiesUrl()

### DIFF
--- a/src/wfs/endpoint.spec.ts
+++ b/src/wfs/endpoint.spec.ts
@@ -673,7 +673,7 @@ describe('WfsEndpoint', () => {
     it('returns the self-reported URL after the capabilities are retrieved', async () => {
       await endpoint.isReady();
       expect(endpoint.getCapabilitiesUrl()).toBe(
-        'https://www.pigma.org/geoserver/wfs?SERVICE=WMS&REQUEST=GetCapabilities'
+        'https://www.pigma.org/geoserver/wfs?SERVICE=WFS&REQUEST=GetCapabilities'
       );
     });
   });

--- a/src/wfs/endpoint.ts
+++ b/src/wfs/endpoint.ts
@@ -308,7 +308,7 @@ export default class WfsEndpoint {
   }
 
   /**
-   * Returns the Capabilities URL of the WMS
+   * Returns the Capabilities URL of the WFS
    *
    * This is the URL reported by the service if available, otherwise the URL
    * passed to the constructor
@@ -319,7 +319,7 @@ export default class WfsEndpoint {
       return this._capabilitiesUrl;
     }
     return setQueryParams(baseUrl, {
-      SERVICE: 'WMS',
+      SERVICE: 'WFS',
       REQUEST: 'GetCapabilities',
     });
   }


### PR DESCRIPTION
WfsEndpoint.getCapabilitiesUrl() was returning a URL with SERVICE=WMS, which is a copy-paste leftover from WmsEndpoint when this method was duplicated into the WFS endpoint.

The bug only manifests after the endpoint is ready, because the method falls back to the constructor URL (correct, SERVICE=WFS) when this.getOperationUrl('GetCapabilities') returns null (i.e., before the capabilities document has been parsed). Once the OperationsMetadata block populates _url, callers get a URL with SERVICE=WMS that most WFS servers either reject or silently misinterpret.

Also corrects the JSDoc header that read "Returns the Capabilities URL of the WMS" for the same copy-paste reason.

The existing test at endpoint.spec.ts:675 was asserting the broken output; its expectation is updated as part of this fix.