### PR TITLE
feat: Add support for dimensions in wms

### DIFF
--- a/fixtures/wms/capabilities-dimensions-1-1-1.xml
+++ b/fixtures/wms/capabilities-dimensions-1-1-1.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE WMT_MS_Capabilities SYSTEM "http://schemas.opengis.net/wms/1.1.1/WMS_MS_Capabilities.dtd">
+<WMT_MS_Capabilities version="1.1.1">
+  <Service>
+    <Name>OGC:WMS</Name>
+    <Title>Dimensions test server</Title>
+  </Service>
+  <Capability>
+    <Layer>
+      <Title>Root</Title>
+      <SRS>EPSG:4326</SRS>
+      <Layer queryable="1">
+        <Name>weather</Name>
+        <Title>Weather</Title>
+        <Dimension name="time" units="ISO8601"/>
+        <Dimension name="elevation" units="EPSG:5030" unitSymbol="m"/>
+        <Extent name="time" default="2024-01-02T00:00:00Z" nearestValue="1" multipleValues="1" current="1">2024-01-01T00:00:00Z,2024-01-02T00:00:00Z,2024-01-03T00:00:00Z</Extent>
+        <Extent name="elevation" default="0">0,1000,3000</Extent>
+      </Layer>
+    </Layer>
+  </Capability>
+</WMT_MS_Capabilities>

--- a/fixtures/wms/capabilities-dimensions-1-3-0.xml
+++ b/fixtures/wms/capabilities-dimensions-1-3-0.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<WMS_Capabilities version="1.3.0" xmlns="http://www.opengis.net/wms">
+  <Service>
+    <Name>WMS</Name>
+    <Title>Dimensions test server</Title>
+  </Service>
+  <Capability>
+    <Layer>
+      <Title>Root</Title>
+      <CRS>EPSG:4326</CRS>
+      <Layer queryable="1">
+        <Name>weather</Name>
+        <Title>Weather</Title>
+        <Dimension name="time" units="ISO8601" default="2024-01-02T00:00:00Z" nearestValue="1" multipleValues="1" current="1">2024-01-01T00:00:00Z,2024-01-02T00:00:00Z,2024-01-03T00:00:00Z</Dimension>
+        <Dimension name="elevation" units="EPSG:5030" unitSymbol="m" default="0">0,1000,3000</Dimension>
+      </Layer>
+    </Layer>
+  </Capability>
+</WMS_Capabilities>

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ export type {
 export { default as WmsEndpoint } from './wms/endpoint.js';
 export type {
   WmsLayerFull,
+  WmsLayerDimension,
   WmsVersion,
   WmsLayerSummary,
   WmsLayerAttribution,

--- a/src/wms/capabilities.spec.ts
+++ b/src/wms/capabilities.spec.ts
@@ -8,6 +8,10 @@ import {
 import capabilities130 from '../../fixtures/wms/capabilities-brgm-1-3-0.xml';
 // @ts-expect-error ts-migrate(7016)
 import capabilities111 from '../../fixtures/wms/capabilities-brgm-1-1-1.xml';
+// @ts-expect-error ts-migrate(7016)
+import dimensions130 from '../../fixtures/wms/capabilities-dimensions-1-3-0.xml';
+// @ts-expect-error ts-migrate(7016)
+import dimensions111 from '../../fixtures/wms/capabilities-dimensions-1-1-1.xml';
 import { parseXmlString } from '../shared/xml-utils.js';
 import type { WmsLayerFull } from './model.js';
 
@@ -296,6 +300,100 @@ describe('WMS capabilities', () => {
       expect(
         readLayersFromCapabilities(doc).map(fixupScaleDenominators)
       ).toEqual(expectedLayers);
+    });
+  });
+
+  describe('layer dimensions', () => {
+    // Same expected output for both versions: the parser normalizes the
+    // WMS 1.1.1 Dimension/Extent split into the 1.3.0 inline representation.
+    const expectedDimensions = [
+      {
+        name: 'time',
+        units: 'ISO8601',
+        defaultValue: '2024-01-02T00:00:00Z',
+        values: [
+          '2024-01-01T00:00:00Z',
+          '2024-01-02T00:00:00Z',
+          '2024-01-03T00:00:00Z',
+        ],
+        nearestValue: true,
+        multipleValues: true,
+        current: true,
+      },
+      {
+        name: 'elevation',
+        units: 'EPSG:5030',
+        unitSymbol: 'm',
+        defaultValue: '0',
+        values: ['0', '1000', '3000'],
+        nearestValue: false,
+        multipleValues: false,
+        current: false,
+      },
+    ];
+    it('reads the dimensions (1.3.0)', () => {
+      const doc = parseXmlString(dimensions130);
+      const [layer] = readLayersFromCapabilities(doc)[0].children;
+      expect(layer.dimensions).toEqual(expectedDimensions);
+    });
+    it('reads the dimensions (1.1.1)', () => {
+      const doc = parseXmlString(dimensions111);
+      const [layer] = readLayersFromCapabilities(doc)[0].children;
+      expect(layer.dimensions).toEqual(expectedDimensions);
+    });
+    it('skips a 1.1.1 Dimension with no matching Extent (no values)', () => {
+      const doc = parseXmlString(`<?xml version="1.0"?>
+        <WMT_MS_Capabilities version="1.1.1">
+          <Capability>
+            <Layer>
+              <Layer queryable="1">
+                <Name>weather</Name>
+                <Title>Weather</Title>
+                <Dimension name="time" units="ISO8601"/>
+              </Layer>
+            </Layer>
+          </Capability>
+        </WMT_MS_Capabilities>`);
+      const [layer] = readLayersFromCapabilities(doc)[0].children;
+      expect(layer.dimensions).toBeUndefined();
+    });
+    it('inherits parent dimensions, child redefinition overriding by name', () => {
+      const doc = parseXmlString(`<?xml version="1.0"?>
+        <WMS_Capabilities version="1.3.0" xmlns="http://www.opengis.net/wms">
+          <Capability>
+            <Layer>
+              <Title>Root</Title>
+              <Dimension name="time" units="ISO8601" default="2024-01-01T00:00:00Z">2024-01-01T00:00:00Z</Dimension>
+              <Dimension name="elevation" units="EPSG:5030" default="0">0,1000</Dimension>
+              <Layer queryable="1">
+                <Name>weather</Name>
+                <Title>Weather</Title>
+                <Dimension name="elevation" units="EPSG:5030" default="3000">3000,5000</Dimension>
+              </Layer>
+            </Layer>
+          </Capability>
+        </WMS_Capabilities>`);
+      const [layer] = readLayersFromCapabilities(doc)[0].children;
+      expect(layer.dimensions).toEqual([
+        {
+          name: 'time',
+          units: 'ISO8601',
+          defaultValue: '2024-01-01T00:00:00Z',
+          values: ['2024-01-01T00:00:00Z'],
+          nearestValue: false,
+          multipleValues: false,
+          current: false,
+        },
+        {
+          name: 'elevation',
+          units: 'EPSG:5030',
+          defaultValue: '3000',
+          values: ['3000', '5000'],
+          nearestValue: false,
+          multipleValues: false,
+          current: false,
+        },
+      ]);
     });
   });
 

--- a/src/wms/capabilities.ts
+++ b/src/wms/capabilities.ts
@@ -19,7 +19,12 @@ import {
   getRootElement,
   stripNamespace,
 } from '../shared/xml-utils.js';
-import { WmsLayerAttribution, WmsLayerFull, WmsVersion } from './model.js';
+import {
+  WmsLayerAttribution,
+  WmsLayerDimension,
+  WmsLayerFull,
+  WmsVersion,
+} from './model.js';
 
 /**
  * Will read all operation URLs from the capabilities doc
@@ -181,7 +186,8 @@ function parseLayer(
   inheritedAttribution: WmsLayerAttribution = null,
   inheritedBoundingBoxes: Record<CrsCode, BoundingBox> = null,
   inheritedMaxScaleDenom: number = null,
-  inheritedMinScaleDenom: number = null
+  inheritedMinScaleDenom: number = null,
+  inheritedDimensions: WmsLayerDimension[] = []
 ): WmsLayerFull {
   const srsTag = version === '1.3.0' ? 'CRS' : 'SRS';
   const srsList = findChildrenElement(layerEl, srsTag).map(getElementText);
@@ -234,6 +240,52 @@ function parseLayer(
   function parseScaleDenominator(name, inheritedValue) {
     const textValue = getElementText(findChildElement(layerEl, name));
     return textValue === '' ? inheritedValue : parseFloat(textValue);
+  }
+  function parseDimensionValues(el: XmlElement): string[] {
+    return getElementText(el)
+      .split(',')
+      .map((value) => value.trim())
+      .filter((value) => value !== '');
+  }
+  // In WMS 1.3.0 the dimension values and their attributes are held directly
+  // by the Dimension element. In WMS 1.1.1 the Dimension element only holds
+  // the metadata (name, units, unitSymbol) while the values and their
+  // attributes (default, nearestValue, multipleValues, current) live in a
+  // sibling Extent element sharing the same name.
+  function parseDimensions(): WmsLayerDimension[] {
+    return (
+      findChildrenElement(layerEl, 'Dimension')
+        .map((dimEl) => {
+          const name = getElementAttribute(dimEl, 'name');
+          const units = getElementAttribute(dimEl, 'units');
+          const unitSymbol = getElementAttribute(dimEl, 'unitSymbol');
+          const valueSource =
+            version === '1.3.0'
+              ? dimEl
+              : findChildrenElement(layerEl, 'Extent').find(
+                  (extentEl) => getElementAttribute(extentEl, 'name') === name
+                ) ?? null;
+          const dimension: WmsLayerDimension = {
+            name,
+            units,
+            defaultValue: getElementAttribute(valueSource, 'default'),
+            values: valueSource ? parseDimensionValues(valueSource) : [],
+            nearestValue:
+              getElementAttribute(valueSource, 'nearestValue') === '1',
+            multipleValues:
+              getElementAttribute(valueSource, 'multipleValues') === '1',
+            current: getElementAttribute(valueSource, 'current') === '1',
+          };
+          if (unitSymbol) {
+            dimension.unitSymbol = unitSymbol;
+          }
+          return dimension;
+        })
+        // A dimension with no resolvable values is not actionable (e.g. a WMS
+        // 1.1.1 Dimension with no matching Extent, or an empty Extent); drop it
+        // so every entry exposed is usable.
+        .filter((dimension) => dimension.values.length > 0)
+    );
   }
   const attributionEl = findChildElement(layerEl, 'Attribution');
   const attribution =
@@ -305,6 +357,17 @@ function parseLayer(
     })
   );
 
+  // Dimensions are inheritable per the WMS spec: a child layer inherits its
+  // ancestors' dimensions, and a dimension it redefines with the same name
+  // replaces the inherited one.
+  const ownDimensions = parseDimensions();
+  const dimensions = [
+    ...inheritedDimensions.filter(
+      (inherited) => !ownDimensions.some((own) => own.name === inherited.name)
+    ),
+    ...ownDimensions,
+  ];
+
   const children = findChildrenElement(layerEl, 'Layer').map((layer) =>
     parseLayer(
       layer,
@@ -314,7 +377,8 @@ function parseLayer(
       attribution,
       boundingBoxes,
       maxScaleDenominator,
-      minScaleDenominator
+      minScaleDenominator,
+      dimensions
     )
   );
   return {
@@ -331,6 +395,7 @@ function parseLayer(
     ...(minScaleDenominator !== null ? { minScaleDenominator } : {}),
     ...(maxScaleDenominator !== null ? { maxScaleDenominator } : {}),
     ...(metadata.length && { metadata }),
+    ...(dimensions.length && { dimensions }),
     ...(children.length && { children }),
   };
 }

--- a/src/wms/endpoint.ts
+++ b/src/wms/endpoint.ts
@@ -156,6 +156,7 @@ export default class WmsEndpoint {
    * @param {BoundingBox} options.extent Expressed in the requested CRS
    * @param {MimeType} options.outputFormat
    * @param {string} [options.styles] List of styles to use, one for each layer requested; leave out or use empty string for default style
+   * @param {Object} [options.dimensions] Dimension values keyed by uppercase dimension name (e.g. { TIME: '...' })
    * @returns Returns null if endpoint is not ready
    */
   getMapUrl(
@@ -167,12 +168,14 @@ export default class WmsEndpoint {
       extent: BoundingBox;
       outputFormat: MimeType;
       styles?: string[];
+      dimensions?: Record<string, string>;
     }
   ) {
     if (!this._layers) {
       return null;
     }
-    const { widthPx, heightPx, crs, extent, outputFormat, styles } = options;
+    const { widthPx, heightPx, crs, extent, outputFormat, styles, dimensions } =
+      options;
     // TODO: check supported CRS
     // TODO: check supported output formats
     // TODO: check supported styles
@@ -185,7 +188,8 @@ export default class WmsEndpoint {
       crs,
       extent,
       outputFormat,
-      styles !== undefined ? styles.join(',') : ''
+      styles !== undefined ? styles.join(',') : '',
+      dimensions
     );
   }
 

--- a/src/wms/model.ts
+++ b/src/wms/model.ts
@@ -11,6 +11,17 @@ export type WmsLayerAttribution = {
   logoUrl?: string;
 };
 
+export type WmsLayerDimension = {
+  name: string;
+  units: string;
+  unitSymbol?: string;
+  defaultValue: string;
+  values: string[];
+  nearestValue: boolean;
+  multipleValues: boolean;
+  current: boolean;
+};
+
 export type WmsLayerSummary = {
   /**
    * The layer is renderable if defined
@@ -44,6 +55,7 @@ export type WmsLayerFull = {
   attribution?: WmsLayerAttribution;
   keywords?: string[];
   metadata?: MetadataURL[];
+  dimensions?: WmsLayerDimension[];
   /**
    * Not defined if the layer is a leaf in the tree
    */

--- a/src/wms/url.spec.ts
+++ b/src/wms/url.spec.ts
@@ -34,4 +34,22 @@ describe('generateGetMapUrl', () => {
       'http://example.com/wms?SERVICE=WMS&REQUEST=GetMap&VERSION=1.3.0&LAYERS=layer1%2Clayer2&STYLES=style1%2Cstyle2&WIDTH=100&HEIGHT=200&FORMAT=image%2Fpng&CRS=EPSG%3A4326&BBOX=10%2C20%2C100%2C200'
     );
   });
+  it('appends dimension values as query params, uppercasing the keys', () => {
+    expect(
+      generateGetMapUrl(
+        'http://example.com/wms',
+        '1.3.0',
+        'layer1',
+        100,
+        200,
+        'EPSG:4326',
+        [10, 20, 100, 200],
+        'image/png',
+        undefined,
+        { time: '2024-01-02T00:00:00Z', elevation: '1000' }
+      )
+    ).toBe(
+      'http://example.com/wms?SERVICE=WMS&REQUEST=GetMap&VERSION=1.3.0&LAYERS=layer1&STYLES=&WIDTH=100&HEIGHT=200&FORMAT=image%2Fpng&CRS=EPSG%3A4326&BBOX=10%2C20%2C100%2C200&TIME=2024-01-02T00%3A00%3A00Z&ELEVATION=1000'
+    );
+  });
 });

--- a/src/wms/url.ts
+++ b/src/wms/url.ts
@@ -13,6 +13,7 @@ import { WmsVersion } from './model.js';
  * @param extent Expressed in the requested CRS
  * @param outputFormat
  * @param [styles] Comma-separated list of styles to use; leave out for default style
+ * @param [dimensions] Dimension values keyed by dimension name (case-insensitive, e.g. { time: '...' })
  */
 export function generateGetMapUrl(
   serviceUrl: string,
@@ -23,7 +24,8 @@ export function generateGetMapUrl(
   crs: CrsCode,
   extent: BoundingBox,
   outputFormat: MimeType,
-  styles?: string
+  styles?: string,
+  dimensions?: Record<string, string>
 ): string {
   const crsParam = version === '1.3.0' ? 'CRS' : 'SRS';
 
@@ -39,6 +41,14 @@ export function generateGetMapUrl(
   newParams['FORMAT'] = outputFormat ?? 'image/png';
   newParams[crsParam] = crs;
   newParams['BBOX'] = extent.join(',');
+
+  // Dimensions are exposed lowercase in the parsed capabilities (e.g. "time"),
+  // but must be uppercased on the wire like every other WMS parameter.
+  if (dimensions) {
+    for (const [name, value] of Object.entries(dimensions)) {
+      newParams[name.toUpperCase()] = value;
+    }
+  }
 
   return setQueryParams(serviceUrl, newParams);
 }


### PR DESCRIPTION
Adds WMS layer dimension support (e.g. time, elevation) to WmsEndpoint — both reading them from capabilities and sending dimension values in GetMap requests.

  Reading
  - New exported WmsLayerDimension type; WmsLayerFull gains an optional dimensions array.
  - Normalizes both wire formats: WMS 1.3.0 inline <Dimension>, and WMS 1.1.1's <Dimension> + sibling <Extent> matched by name.
  - Dimensions with no resolvable values are dropped.
  - Dimensions are inherited by child layers (same-name redefinition overrides), consistent with CRS/styles/bbox inheritance.

  Building GetMap URLs
  - getMapUrl() accepts an optional dimensions (Record<string, string>).
  - Keys are uppercased onto the wire, so callers pass natural dimension names ({ time: '…' })

  Testing — fixtures for both versions plus coverage for parsing, value-less skipping, inheritance override, and query-param generation. 15 WMS tests pass.

  Note — value ranges (start/end) not yet modeled; enumerated/single values only.

With some help of my fellow @claude

