### PR TITLE
Avoid pulling full collection on initial `/items` load

### DIFF
--- a/src/ogc-api/link-utils.spec.ts
+++ b/src/ogc-api/link-utils.spec.ts
@@ -35,6 +35,61 @@ describe('link-utils', () => {
     });
   });
 
+  const itemsResponse = {
+    ok: true,
+    clone: () => ({ json: () => Promise.resolve({ features: [] }) }),
+  };
+  const firstFetchedUrl = () =>
+    new URL((httpUtils.sharedFetch as jest.Mock).mock.calls[0][0]);
+
+  describe('fetchRoot with an /items initial url', () => {
+    it('forces limit=1 even if the url already has a larger limit', async () => {
+      const landingPage = {
+        links: [
+          { rel: 'service-desc', href: 'https://example.com/api?f=json' },
+          { rel: 'conformance', href: 'https://example.com/conformance' },
+        ],
+      };
+      (httpUtils.sharedFetch as jest.Mock)
+        .mockResolvedValueOnce(itemsResponse)
+        .mockResolvedValue({
+          ok: true,
+          clone: () => ({ json: () => Promise.resolve(landingPage) }),
+        });
+
+      await linkUtils.fetchRoot(
+        'https://example.com/collections/big/items?limit=500'
+      );
+
+      expect(firstFetchedUrl().pathname).toBe('/collections/big/items');
+      expect(firstFetchedUrl().searchParams.get('limit')).toBe('1');
+    });
+  });
+
+  describe('fetchCollectionRoot with an /items initial url', () => {
+    it('adds limit=1 to an /items url that has no limit', async () => {
+      const collection = {
+        id: 'big',
+        links: [
+          { rel: 'items', href: 'https://example.com/collections/big/items' },
+        ],
+      };
+      (httpUtils.sharedFetch as jest.Mock)
+        .mockResolvedValueOnce(itemsResponse)
+        .mockResolvedValue({
+          ok: true,
+          clone: () => ({ json: () => Promise.resolve(collection) }),
+        });
+
+      await linkUtils.fetchCollectionRoot(
+        'https://example.com/collections/big/items'
+      );
+
+      expect(firstFetchedUrl().pathname).toBe('/collections/big/items');
+      expect(firstFetchedUrl().searchParams.get('limit')).toBe('1');
+    });
+  });
+
   describe('getLinks', () => {
     it('returns links matching the provided rel type', () => {
       const mockDoc: OgcApiDocument = {

--- a/src/ogc-api/link-utils.ts
+++ b/src/ogc-api/link-utils.ts
@@ -7,6 +7,16 @@ import { EndpointError } from '../shared/errors.js';
 import { sharedFetch } from '../shared/http-utils.js';
 import { getParentPath, getBaseUrl } from '../shared/url-utils.js';
 
+// During endpoint discovery we may fetch an `/items` URL just to inspect its links.
+// Cap that response so initial endpoint loading does not pull a full collection.
+function capItemsForDiscovery(url: string): string {
+  const urlObj = new URL(url, getBaseUrl());
+  if (urlObj.pathname.replace(/\/$/, '').endsWith('/items')) {
+    urlObj.searchParams.set('limit', '1');
+  }
+  return urlObj.toString();
+}
+
 export function fetchDocument<T extends OgcApiDocument>(
   url: string
 ): Promise<T> {
@@ -40,7 +50,7 @@ function checkIsLandingPage(doc: OgcApiDocument): boolean {
 }
 
 export function fetchRoot(url: string): Promise<OgcApiDocument> {
-  return fetchDocument(url).then((doc) => {
+  return fetchDocument(capItemsForDiscovery(url)).then((doc) => {
     // if no data link, attempt to look at the parent
     if (!checkIsLandingPage(doc)) {
       const parentUrl = getParentPath(url);
@@ -60,7 +70,7 @@ export function fetchRoot(url: string): Promise<OgcApiDocument> {
 export function fetchCollectionRoot(
   url: string
 ): Promise<OgcApiDocument | null> {
-  return fetchDocument(url).then((doc) => {
+  return fetchDocument(capItemsForDiscovery(url)).then((doc) => {
     // this looks like the root; return null
     if (checkIsLandingPage(doc)) {
       return null;


### PR DESCRIPTION
### Description

This PR introduces a fix for slow initial loading of OGC API endpoints created from an `/items` URL.

During discovery, `fetchRoot` / `fetchCollectionRoot` fetched the `/items` document just to read its links, pulling the server's full default page (potentially the entire collection).

This adds `capItemsForDiscovery()`, which forces `limit=1` on `/items` URLs during discovery only. Actual item retrieval is unaffected.
