### PR TITLE
chore: point to the ESM modules if the library is used with ESM imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/dist-node.js",
+      "import": "./dist/index.js",
       "browser": "./dist/index.js",
       "default": "./dist/dist-node.js"
     }


### PR DESCRIPTION
This avoids front-end applications pointing to the full node bundle and let them treeshake whatever ESM module they need in the library.