### PR TITLE
fix(cache): handle task rejection in useCache

### DIFF
--- a/src/shared/cache.ts
+++ b/src/shared/cache.ts
@@ -107,7 +107,8 @@ export async function useCache<T>(
   }
   const taskRun = factory();
   if (taskRun instanceof Promise) {
-    taskRun.then(() => tasksMap.delete(taskKey));
+    const clear = () => tasksMap.delete(taskKey);
+    taskRun.then(clear, clear);
     tasksMap.set(taskKey, taskRun);
   }
   const result = await taskRun;


### PR DESCRIPTION
`taskRun.then(() => tasksMap.delete(taskKey))` only registered a fulfillment handler, which caused two problems when a task rejected:

- the **derived promise rejected with no handler attached**, surfacing as an `Uncaught (in promise)` error in the console even though the caller of `useCache` did catch the rejection it received;
- the **entry was never removed from tasksMap**, so the rejected promise stayed there for the lifetime of the page and every subsequent call with the same keys replayed that rejection instead of retrying.

Registering the same clearing callback for both outcomes fixes both.

This is visible with `NcwmsEndpoint.getLayerDetails()`, where a `GetMetadata` request against a plain WMS server is expected to fail.